### PR TITLE
[BUGFIX] Correctly handle escaped quotes

### DIFF
--- a/Classes/Service/CsvService.php
+++ b/Classes/Service/CsvService.php
@@ -48,6 +48,7 @@ class CsvService
                     }
                     $currentField = '';
                     $fieldsStack = [];
+                    $skippedQuote = false;
                 }
                 // is it the end of a field or just within in the quote?
             } elseif ($str{$i} == $delimiter) {
@@ -56,6 +57,7 @@ class CsvService
                 } else {
                     $fieldsStack[] = $currentField;
                     $currentField = '';
+                    $skippedQuote = false;
                 }
             } elseif ($useQualifier && $str{$i} == $qualifier) {
                 if ($isInQuote) {
@@ -69,6 +71,7 @@ class CsvService
                 } else {
                     if ($skippedQuote) {
                         $skippedQuote = false;
+                        $currentField .= $qualifier;
                     }
                     $isInQuote = true;
                 }


### PR DESCRIPTION
If a field contains 2 double quotes within quotes we should add the quotes to the field.

Also, if we skip a quote and start a new field the variable 'skippedQuote' remained true.
This patch handles that as well to avoid quotes being added to fields where they should not.